### PR TITLE
Fix import submodule

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/odhondt/eo_tools/archive/{{ version }}.tar.gz
-  sha256: 2c5cb66a1dcb5ecf1db7eeab9b7c5b2a0db66bd7bc701db14503dcf21fa6f80f
+  sha256: aabebdafb07061c373a6a34c3583f41652f38683f1b54f8dfbaeb853160f3206
 
 build:
   noarch: python
@@ -52,6 +52,7 @@ requirements:
 test:
   imports:
     - eo_tools
+    - eo_tools.S1
 
 about:
   home: https://github.com/odhondt/eo_tools


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Problem: import of the `eo_tools.S1` submodule was failing. 
I have:
- Updated the `packages` section in my `pyproject.toml` on my home repo with this submodule
- Updated the current version with this changed file on my home repo
- Updated the `meta.yaml` recipe with the new sha256 number and included the imports of `eo_tools.S1` in the tests

<!--
Please add any other relevant info below:
-->
